### PR TITLE
Use Stream in request body

### DIFF
--- a/src/templates/core/node/getRequestBody.hbs
+++ b/src/templates/core/node/getRequestBody.hbs
@@ -3,7 +3,7 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
         return getFormData(options.formData) as BodyInit;
     }
     if (options.body) {
-        if (isString(options.body) || isBinary(options.body)) {
+        if (isString(options.body) || isBinary(options.body) || options.body instanceof Stream)) {
             return options.body as BodyInit;
         } else {
             return JSON.stringify(options.body);

--- a/src/templates/core/node/request.hbs
+++ b/src/templates/core/node/request.hbs
@@ -2,6 +2,7 @@
 
 import FormData from 'form-data';
 import fetch, { BodyInit, Headers, RequestInit, Response } from 'node-fetch';
+import { Stream } from 'stream';
 import { types } from 'util';
 
 import { ApiError } from './ApiError';


### PR DESCRIPTION
Fix for allowing the `node-fetch` version of the generated openapi to allow for using Stream as request body.