### PR TITLE
Remove wrong parenthese and correct header for Stream request body

### DIFF
--- a/src/templates/core/node/getHeaders.hbs
+++ b/src/templates/core/node/getHeaders.hbs
@@ -19,7 +19,7 @@ async function getHeaders(options: ApiRequestOptions): Promise<Headers> {
     }
 
     if (options.body) {
-        if (isBinary(options.body)) {
+        if (isBinary(options.body) || options.body instanceof Stream) {
             headers.append('Content-Type', 'application/octet-stream');
         } else if (isString(options.body)) {
             headers.append('Content-Type', 'text/plain');

--- a/src/templates/core/node/getRequestBody.hbs
+++ b/src/templates/core/node/getRequestBody.hbs
@@ -3,7 +3,7 @@ function getRequestBody(options: ApiRequestOptions): BodyInit | undefined {
         return getFormData(options.formData) as BodyInit;
     }
     if (options.body) {
-        if (isString(options.body) || isBinary(options.body) || options.body instanceof Stream)) {
+        if (isString(options.body) || isBinary(options.body) || options.body instanceof Stream) {
             return options.body as BodyInit;
         } else {
             return JSON.stringify(options.body);


### PR DESCRIPTION
### Changes:
- An extra parenthese ended up in the template. Should be removed.
- Add correct header for Stream request body